### PR TITLE
feat: add support for opening xcancel rss links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
                 <data android:host="nitter.net" />
                 <data android:host="t.co" />
                 <data android:host="xcancel.com" />
+                <data android:host="rss.xcancel.com" />
                 <data android:host="vxtwitter.com" />
                 <data android:host="fxtwitter.com" />
             </intent-filter>


### PR DESCRIPTION
when subscribing to xcancel rss feeds the links have a `rss.` prefix/subdomain. this will allow opening such links inside Nitterium