### PR TITLE
Optional per-instance access key, sent in the User-Agent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- Set the access key from a link: nitterium://instance?url=...&key=...
+                 Lets a key be taken over from a QR code or a setup link instead
+                 of typing 32 characters by hand. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="nitterium" android:host="instance" />
+            </intent-filter>
+
             <!-- Deep Links -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/com/kaleedtc/nitterium/MainActivity.kt
+++ b/app/src/main/java/com/kaleedtc/nitterium/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.kaleedtc.nitterium
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -20,6 +22,9 @@ import com.kaleedtc.nitterium.ui.common.LocalFullScreenMode
 import com.kaleedtc.nitterium.ui.common.viewModelFactory
 import com.kaleedtc.nitterium.ui.theme.NitteriumTheme
 
+import com.kaleedtc.nitterium.data.repository.UserPreferencesRepository
+import kotlinx.coroutines.launch
+
 class MainActivity : ComponentActivity() {
 
     private val intentUrl = mutableStateOf<String?>(null)
@@ -28,7 +33,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        intentUrl.value = intent?.dataString
+        intentUrl.value = if (acceptInstanceKey(intent)) null else intent?.dataString
 
         val app = application as NitteriumApplication
         val viewModel: MainViewModel by viewModels {
@@ -85,6 +90,31 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: android.content.Intent) {
         super.onNewIntent(intent)
-        intentUrl.value = intent.dataString
+        intentUrl.value = if (acceptInstanceKey(intent)) null else intent.dataString
+    }
+
+    /**
+     * Takes an access key from a link:
+     * `nitterium://instance?url=https://nitter.example&key=...`
+     *
+     * Meant for QR codes and setup links - typing 32 characters on a phone is
+     * error prone. Returns true when the link carried a key and must not be
+     * opened as a page.
+     */
+    private fun acceptInstanceKey(intent: android.content.Intent?): Boolean {
+        val data = intent?.data ?: return false
+        if (data.scheme != "nitterium" || data.host != "instance") return false
+        val url = data.getQueryParameter("url") ?: data.getQueryParameter("host") ?: return true
+        val key = data.getQueryParameter("key").orEmpty()
+        val app = application as NitteriumApplication
+        lifecycleScope.launch {
+            app.userPreferencesRepository.setInstanceKey(url, key)
+        }
+        Toast.makeText(
+            this,
+            getString(R.string.instance_key_imported, UserPreferencesRepository.hostOf(url)),
+            Toast.LENGTH_LONG
+        ).show()
+        return true
     }
 }

--- a/app/src/main/java/com/kaleedtc/nitterium/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/kaleedtc/nitterium/data/repository/UserPreferencesRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_preferences")
 
@@ -27,6 +28,7 @@ class UserPreferencesRepository(
         val DEFAULT_TAB = stringPreferencesKey("default_tab")
         val BLOCK_DIRECT_X = booleanPreferencesKey("block_direct_x")
         val CUSTOM_INSTANCES = androidx.datastore.preferences.core.stringSetPreferencesKey("custom_instances")
+        val INSTANCE_KEYS = stringPreferencesKey("instance_keys")
     }
 
     val instanceUrl: Flow<String> = context.dataStore.data
@@ -138,6 +140,46 @@ class UserPreferencesRepository(
     suspend fun setBlockDirectX(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.BLOCK_DIRECT_X] = enabled
+        }
+    }
+
+    /**
+     * Access keys per instance, stored as JSON `{host: key}`.
+     *
+     * Some instances - self-hosted ones in particular - only serve their
+     * expensive paths to requests that can identify themselves. The key
+     * therefore belongs to the instance, not to the app: it is sent to the
+     * host it was entered for and never to any other instance.
+     */
+    val instanceKeys: Flow<Map<String, String>> = context.dataStore.data
+        .map { preferences -> readKeys(preferences[PreferencesKeys.INSTANCE_KEYS]) }
+
+    fun instanceKeyFor(url: String): Flow<String> =
+        instanceKeys.map { it[hostOf(url)] ?: "" }
+
+    suspend fun setInstanceKey(url: String, key: String) {
+        val host = hostOf(url)
+        context.dataStore.edit { preferences ->
+            val map = readKeys(preferences[PreferencesKeys.INSTANCE_KEYS]).toMutableMap()
+            if (key.isBlank()) map.remove(host) else map[host] = key.trim()
+            preferences[PreferencesKeys.INSTANCE_KEYS] = Json.encodeToString(map)
+        }
+    }
+
+    companion object {
+        private fun readKeys(raw: String?): Map<String, String> =
+            if (raw.isNullOrBlank()) emptyMap()
+            else try {
+                Json.decodeFromString<Map<String, String>>(raw)
+            } catch (_: Exception) {
+                emptyMap()
+            }
+
+        /** Only the host matters - not the scheme, the port or trailing slashes. */
+        fun hostOf(url: String): String = try {
+            java.net.URI(url.trim()).host?.lowercase() ?: url.trim().lowercase()
+        } catch (_: Exception) {
+            url.trim().lowercase()
         }
     }
 }

--- a/app/src/main/java/com/kaleedtc/nitterium/ui/common/NitterWebView.kt
+++ b/app/src/main/java/com/kaleedtc/nitterium/ui/common/NitterWebView.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import com.kaleedtc.nitterium.data.repository.UserPreferencesRepository
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -90,6 +92,14 @@ fun NitterWebView(
 
     var longPressedUrl by remember { mutableStateOf<String?>(null) }
     val context = LocalContext.current
+
+    // Access key for this instance (from settings). It is appended to the
+    // user agent and therefore only ever reaches the host it was entered for -
+    // instances that open single paths to known clients let the app through
+    // without anyone needing a fixed IP address.
+    val preferencesRepository = remember { UserPreferencesRepository(context) }
+    val instanceKeys by preferencesRepository.instanceKeys.collectAsState(initial = emptyMap())
+    val instanceKey = instanceKeys[UserPreferencesRepository.hostOf(url)] ?: ""
 
     DisposableEffect(Unit) {
         onDispose {
@@ -422,6 +432,20 @@ fun NitterWebView(
 
     Box(modifier = modifier.fillMaxSize()) {
         var webViewRef by remember { mutableStateOf<WebView?>(null) }
+
+        // When the key is changed in settings, hand the new user agent to the
+        // WebView that is already running and reload.
+        LaunchedEffect(instanceKey, webViewRef) {
+            val view = webViewRef ?: return@LaunchedEffect
+            val wanted = withKey(
+                view.settings.userAgentString.substringBefore(" Nitterium/"),
+                instanceKey
+            )
+            if (view.settings.userAgentString != wanted) {
+                view.settings.userAgentString = wanted
+                view.reload()
+            }
+        }
         val webViewStateBundle = rememberSaveable(
             saver = Saver(
             save = {
@@ -508,8 +532,11 @@ fun NitterWebView(
                         cacheMode = android.webkit.WebSettings.LOAD_DEFAULT
                         mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
                         val defaultUA = userAgentString
-                        userAgentString = defaultUA.replace("; wv", "")
-                            .replace(Regex("Version/\\d+\\.\\d+\\s+"), "")
+                        userAgentString = withKey(
+                            defaultUA.replace("; wv", "")
+                                .replace(Regex("Version/\\d+\\.\\d+\\s+"), ""),
+                            instanceKey
+                        )
                     }
 
                     // Enable third party cookies for better instance compatibility
@@ -888,3 +915,7 @@ class NitterInterface(
         onOpenGallery(list, initialIndex)
     }
 }
+
+/** Appends the instance access key to the user agent; unchanged without a key. */
+private fun withKey(userAgent: String, key: String): String =
+    if (key.isBlank()) userAgent else "$userAgent Nitterium/${key.trim()}"

--- a/app/src/main/java/com/kaleedtc/nitterium/ui/feature/settings/SettingsContract.kt
+++ b/app/src/main/java/com/kaleedtc/nitterium/ui/feature/settings/SettingsContract.kt
@@ -5,6 +5,7 @@ import com.kaleedtc.nitterium.data.model.NitterInstanceSettings
 data class SettingsState(
     val isLoading: Boolean = true,
     val instanceUrl: String = "https://nitter.net",
+    val instanceKey: String = "",
     val isDynamicColor: Boolean = true,
     val isTrueBlack: Boolean = false,
     val isSiteHeaderEnabled: Boolean = false,
@@ -20,6 +21,7 @@ data class SettingsState(
 
 sealed interface SettingsEvent {
     data class UpdateInstanceUrl(val url: String) : SettingsEvent
+    data class UpdateInstanceKey(val key: String) : SettingsEvent
     data class AddCustomInstance(val url: String) : SettingsEvent
     data class RemoveCustomInstance(val url: String) : SettingsEvent
     data class UpdateDynamicColor(val enabled: Boolean) : SettingsEvent

--- a/app/src/main/java/com/kaleedtc/nitterium/ui/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kaleedtc/nitterium/ui/feature/settings/SettingsScreen.kt
@@ -274,6 +274,27 @@ fun AppSettingsList(
                 }
             }
 
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Access key of the selected instance. It rides along in the user
+            // agent and goes to this host only - instances that keep expensive
+            // paths behind an allowlist let the app through with it.
+            var keyInput by rememberSaveable(state.instanceUrl) { mutableStateOf(state.instanceKey) }
+            LaunchedEffect(state.instanceKey) {
+                if (keyInput.isEmpty() && state.instanceKey.isNotEmpty()) keyInput = state.instanceKey
+            }
+            OutlinedTextField(
+                value = keyInput,
+                onValueChange = {
+                    keyInput = it
+                    onEvent(SettingsEvent.UpdateInstanceKey(it))
+                },
+                label = { Text(stringResource(R.string.instance_access_key)) },
+                placeholder = { Text(stringResource(R.string.instance_access_key_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
             Spacer(modifier = Modifier.height(24.dp))
         }
 

--- a/app/src/main/java/com/kaleedtc/nitterium/ui/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/kaleedtc/nitterium/ui/feature/settings/SettingsViewModel.kt
@@ -44,6 +44,7 @@ class SettingsViewModel(
                 preferencesRepository.darkTheme,
                 preferencesRepository.blockDirectX,
                 preferencesRepository.customInstances,
+                preferencesRepository.instanceKeys,
                 _instanceSettings
             ) { args ->
                 val url = args[0] as String
@@ -56,13 +57,16 @@ class SettingsViewModel(
                 val blockDirectX = args[7] as Boolean
                 @Suppress("UNCHECKED_CAST")
                 val customInstances = (args[8] as Set<String>).toList()
-                val instanceSettings = args[9] as NitterInstanceSettings
+                @Suppress("UNCHECKED_CAST")
+                val instanceKeys = args[9] as Map<String, String>
+                val instanceSettings = args[10] as NitterInstanceSettings
 
                 val allInstances = availableInstances + customInstances
 
                 SettingsState(
                     isLoading = false,
                     instanceUrl = url,
+                    instanceKey = instanceKeys[UserPreferencesRepository.hostOf(url)] ?: "",
                     isDynamicColor = dynamic,
                     isTrueBlack = trueBlack,
                     isSiteHeaderEnabled = siteHeader,
@@ -129,6 +133,11 @@ class SettingsViewModel(
             is SettingsEvent.UpdateInstanceUrl -> {
                 viewModelScope.launch {
                     preferencesRepository.setInstanceUrl(event.url)
+                }
+            }
+            is SettingsEvent.UpdateInstanceKey -> {
+                viewModelScope.launch {
+                    preferencesRepository.setInstanceKey(state.value.instanceUrl, event.key)
                 }
             }
             is SettingsEvent.AddCustomInstance -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,9 @@
     <string name="instance_options">Instance Options</string>
     <string name="network">Network</string>
     <string name="nitter_instance_url">Nitter Instance URL</string>
+    <string name="instance_access_key">Instance access key (optional)</string>
+    <string name="instance_access_key_hint">Sent to this instance only</string>
+    <string name="instance_key_imported">Access key saved for %1$s</string>
     <string name="appearance">Appearance</string>
     <string name="dynamic_color">Dynamic Color</string>
     <string name="true_black">True Black (OLED)</string>


### PR DESCRIPTION
Thanks for Nitterium — it is the client I use daily against my own Nitter instance.

## The problem

A self-hosted instance has to protect one path: the tweet detail pages (`/<user>/status/<id>`). Every request there is a cache miss by construction and costs one API call on the instance's single X session. Scraper pools hammer exactly that path — I measured 77 requests from 77 different IPs in 5.5 minutes, each one a different tweet ID, so per-IP rate limiting cannot help.

The usual answer is an IP allowlist in the reverse proxy. That works at home and fails everywhere else: on mobile data, or after the router gets a new IPv6 prefix, the app hits its own instance and gets a 403. From the user's side it just looks like the app is broken — replies and threads stop loading.

## What this PR does

An **optional access key per instance**, empty by default, so nothing changes for anyone who does not use it.

- A text field under the instance URL in Settings: *Instance access key (optional)*, hint *Sent to this instance only*.
- Stored per **host** (`instance_keys`, JSON `{host: key}` in the existing DataStore), so it follows the instance rather than the app. A key entered for one instance is never sent to another.
- `NitterWebView` appends ` Nitterium/<key>` to the user agent of the instance currently loaded; a `LaunchedEffect` updates a running WebView and reloads when the key changes.
- Entering it without typing: the app accepts `nitterium://instance?url=<instance>&key=<key>`. Printed as a QR code, the system camera app is enough — **no camera library and no camera permission** are added.

The operator then needs one line, e.g. with Apache:

```apache
<LocationMatch "^/[A-Za-z0-9_]+/status/[0-9]+">
    Require ip 127.0.0.1 ::1 …
    Require expr "%{HTTP_USER_AGENT} =~ m#Nitterium/<key>#"
</LocationMatch>
```

8 files, 154 insertions, no new dependency. Compiles clean against `main` (`compileReleaseKotlin`).

## Tested in production

Against my instance (Android 16), same phone, same mobile network, WLAN off, key entered by scanning the QR code:

```
"GET /<user>/status/<id>"   403   (no key)
"GET /<user>/status/<id>"   200   (… Mobile Safari/537.36 Nitterium/<key>)
```

Timelines, profiles, search and images were never restricted and are unaffected; requests without the key still get the 403.

## One fix that came out of it

The settings text field has to keep its own local state. Bound straight to the DataStore value, fast typing overtakes the asynchronous round trip and single characters are dropped — visible as a mangled key. The existing instance URL field has the same shape, so it is likely affected too.

Happy to reshape this however you prefer — for example storing the key inside `NitterInstanceSettings` instead of a separate map, or using a different name for the user-agent token.
